### PR TITLE
Fixed minor bug in Language Picker (Chrome for Linux)

### DIFF
--- a/components/LangPicker.vue
+++ b/components/LangPicker.vue
@@ -70,5 +70,8 @@ export default {
     font-size: 18px;
     line-height: 40px;
     padding: 0 40px 0 12px;
+    option {
+      color: black;
+    }
   }
 </style>


### PR DESCRIPTION
In Chromium, if a color is not defined for options in a dropdown, they can take on a random color, often white on the white background, leading to the text being unreadable. Manually setting the color of the options fixes this.