### PR TITLE
Fix problem where browser language does not have locale.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ If a new language is added on crowdin, you will need to add it into the [update-
 
 When the cron runs and adds any new languages to the repository, (look in the [locales](./locales) folder), you will need to edit [nuxt.config.js](./nuxt-config.js) to add this to the 'nuxt-i18n' locales section.
 
+If the language is also right-to-left, you will need to update [typography.scss](./assets/typography.scss) to set the text alignment for the language.  Add another selector, e.g. `html[lang="ar-SA"]` to this rule:
+
+```css
+html[lang="ar-SA"] {
+  direction: rtl;
+}
+```
+
 ### Building
 
 `docker build -f crowdin.dockerfile . -t crowdin-cd-com`

--- a/assets/typography.scss
+++ b/assets/typography.scss
@@ -11,6 +11,10 @@ html {
   color: $black;
 }
 
+html[lang="ar-SA"] {
+  direction: rtl;
+}
+
 h1, h2, h3 {
   font-family: 'Libre Franklin', sans-serif;
 }
@@ -47,5 +51,5 @@ h3 {
   }
   h3 {
     font-size: 18px;
-  }  
+  }
 }

--- a/components/LangPicker.vue
+++ b/components/LangPicker.vue
@@ -32,7 +32,7 @@ export default {
     closestMatchingLocale() {
       const browserLocaleCode = navigator.language;
       const browserLocaleShortCode = navigator.language.split('-')[0];
-      const matchingCode = this.$i18n.locales.find(locale => locale.code === browserLocaleCode);
+      const matchingCode = this.$i18n.locales.find(locale => locale.code === browserLocaleCode || locale.shortcode === browserLocaleCode);
       if (matchingCode) return matchingCode.code;
       const matchingShortCode = this.$i18n.locales.find(locale => locale.shortCode === browserLocaleShortCode);
       if (matchingShortCode) return matchingShortCode.code;


### PR DESCRIPTION
If you set your browser language to 'Arabic' in Chrome, the preferred language is
'ar', but the language picker was looking for the locale, e.g. wants 'ar-SA'.
Fix to check both locale and shortcode.
Add in rtl text direction to CSS for Arabic
Update README with instructions for adding to this.


If you set your browser language to Arabic and visit https://deploy-preview-65--cdf-website.netlify.app/, the page should redirect to https://deploy-preview-65--cdf-website.netlify.app/ar-SA