### PR TITLE
Remove badges link in footer

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -38,7 +38,6 @@
         </div>
         <div class="c-footer__links">
           <p class="c-footer__links-header">{{ $t('Community') }}</p>
-          <a href="https://zen.coderdojo.com/badges">{{ $t('Badges') }}</a>
           <a href="/news">{{ $t('News') }}</a>
           <a href="/girlsinitiative/">{{ $t('Girls initiative') }}</a>
           <a href="/coderdojo-global-slack/">{{ $t('Join our Slack') }}</a>

--- a/locales/ar-SA.json
+++ b/locales/ar-SA.json
@@ -15,7 +15,6 @@
   "Our supporters": "مؤيدينا",
   "Contact Us": "اتصل بنا",
   "Community": "المجتمع",
-  "Badges": "شارات",
   "Join our Slack": "الانضمام لدينا في منصة Slack",
   "Newsletter": "النشرة الإخبارية",
   "News": "أخبار",

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -15,7 +15,6 @@
   "Our supporters": "Unsere Unterstützer",
   "Contact Us": "Nimm Kontakt zu uns auf",
   "Community": "Community",
-  "Badges": "Abzeichen",
   "Join our Slack": "Tritt uns auf Slack bei",
   "Newsletter": "Newsletter",
   "News": "Neuigkeiten",

--- a/locales/el-GR.json
+++ b/locales/el-GR.json
@@ -15,7 +15,6 @@
   "Our supporters": "Οι υποστηρικτές μας",
   "Contact Us": "Επικοινωνία",
   "Community": "Κοινότητα",
-  "Badges": "Σήματα",
   "Join our Slack": "Γίνε μέλος στην ομάδα μας στο Slack",
   "Newsletter": "Ενημερωτικό δελτίο",
   "News": "Νέα",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -15,7 +15,6 @@
   "Our supporters": "Our supporters",
   "Contact Us": "Contact Us",
   "Community": "Community",
-  "Badges": "Badges",
   "Join our Slack": "Join our Slack",
   "Newsletter": "Newsletter",
   "News": "News",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -15,7 +15,6 @@
   "Our supporters": "Nuestros colaboradores",
   "Contact Us": "Contáctanos",
   "Community": "Comunidad",
-  "Badges": "Insignias",
   "Join our Slack": "Únete a nuestro espacio de trabajo en Slack",
   "Newsletter": "Boletín informativo",
   "News": "Noticias",

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -15,7 +15,6 @@
   "Our supporters": "Nos partenaires",
   "Contact Us": "Nous contacter",
   "Community": "Communauté",
-  "Badges": "Badges",
   "Join our Slack": "Rejoindre Slack",
   "Newsletter": "Bulletin d'information (newsletter)",
   "News": "Actualités",

--- a/locales/hi-IN.json
+++ b/locales/hi-IN.json
@@ -15,7 +15,6 @@
   "Our supporters": "हमारे समर्थक",
   "Contact Us": "हमसे संपर्क करें",
   "Community": "समुदाय",
-  "Badges": "पदक",
   "Join our Slack": "हमारे Slack में शामिल हों",
   "Newsletter": "समाचार पत्रिका",
   "News": "समाचार",

--- a/locales/hu-HU.json
+++ b/locales/hu-HU.json
@@ -15,7 +15,6 @@
   "Our supporters": "Támogatóink",
   "Contact Us": "Kapcsolatfelvétel",
   "Community": "Közösség",
-  "Badges": "Jelvények",
   "Join our Slack": "Csatlakozz a Slack csatornánkhoz",
   "Newsletter": "Hírlevél",
   "News": "Hírek",

--- a/locales/it-IT.json
+++ b/locales/it-IT.json
@@ -15,7 +15,6 @@
   "Our supporters": "I nostri sostenitori",
   "Contact Us": "Contattaci",
   "Community": "La Community",
-  "Badges": "Distintivi",
   "Join our Slack": "Unisciti al nostro canale Slack",
   "Newsletter": "Newsletter",
   "News": "Novità",

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -15,7 +15,6 @@
   "Our supporters": "サポーター",
   "Contact Us": "問い合わせ",
   "Community": "コミュニティ",
-  "Badges": "バッジ",
   "Join our Slack": "Slackに参加する",
   "Newsletter": "ニュースレター",
   "News": "ニュース",

--- a/locales/ko-KR.json
+++ b/locales/ko-KR.json
@@ -15,7 +15,6 @@
   "Our supporters": "도움을 주시는 분들",
   "Contact Us": "문의하기",
   "Community": "커뮤니티",
-  "Badges": "배지",
   "Join our Slack": "Slack(슬랙) 채널 참여하기",
   "Newsletter": "뉴스레터",
   "News": "뉴스",

--- a/locales/nl-NL.json
+++ b/locales/nl-NL.json
@@ -15,7 +15,6 @@
   "Our supporters": "Onze leden",
   "Contact Us": "Contact",
   "Community": "Gemeenschap",
-  "Badges": "Badges",
   "Join our Slack": "Sluit je aan bij onze Slack",
   "Newsletter": "Nieuwsbrief",
   "News": "Nieuws",

--- a/locales/pl-PL.json
+++ b/locales/pl-PL.json
@@ -15,7 +15,6 @@
   "Our supporters": "Wspierają nas",
   "Contact Us": "Skontaktuj się z nami",
   "Community": "Społeczność",
-  "Badges": "Odznaki",
   "Join our Slack": "Dołącz do naszego zespołu w komunikatorze Slack",
   "Newsletter": "Biuletyn informacyjny",
   "News": "Aktualności",

--- a/locales/ro-RO.json
+++ b/locales/ro-RO.json
@@ -15,7 +15,6 @@
   "Our supporters": "Suporterii noştri",
   "Contact Us": "Contactează-ne",
   "Community": "Comunitate",
-  "Badges": "Embleme",
   "Join our Slack": "Alătură-te grupului nostru pe Slack",
   "Newsletter": "Newsletter",
   "News": "Noutăți",

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -15,7 +15,6 @@
   "Our supporters": "Destekçilerimiz",
   "Contact Us": "İletişim",
   "Community": "Topluluk",
-  "Badges": "Rozetler",
   "Join our Slack": "Slack grubumuza katılın",
   "Newsletter": "Haber Bülteni",
   "News": "Haberler",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -15,7 +15,6 @@
   "Our supporters": "我们的支持者",
   "Contact Us": "联系我们",
   "Community": "社群",
-  "Badges": "徽章",
   "Join our Slack": "加入我们的Slack",
   "Newsletter": "新闻简报",
   "News": "新闻",


### PR DESCRIPTION
This is the first step in removing mentions of the now defunct badges service.